### PR TITLE
:memo: add correct npm tag link in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@ redux-meta-object-to-axios-request
 =============
 
 [![CircleCI](https://circleci.com/gh/enkidevs/redux-meta-object-to-axios-request.svg?style=svg)](https://circleci.com/gh/enkidevs/redux-meta-object-to-axios-request)
-[![npm version](https://img.shields.io/npm/v/redux-meta-object-to-axios-request.svg?style=flat-square)](https://www.npmjs.com/package/redux-meta-object-to-axios-request)
+[![npm version](https://img.shields.io/npm/v/redux-meta-object-to-axios-request.svg?style=flat-square)](https://www.npmjs.com/package/@enkidevs/redux-meta-object-to-axios-request)
 
 Redux [middleware](http://rackt.github.io/redux/docs/advanced/Middleware.html) middleware to transform an object into a promise.
 


### PR DESCRIPTION
:memo: add correct npm tag link in the README