### PR TITLE
Remove cancellation helper that is not supported anymore

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7795,7 +7795,8 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/growly/-/growly-1.3.0.tgz",
       "integrity": "sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "har-schema": {
       "version": "2.0.0",
@@ -8442,8 +8443,7 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
       "integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-      "dev": true,
-      "optional": true
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -8594,6 +8594,7 @@
       "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-2.2.0.tgz",
       "integrity": "sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==",
       "dev": true,
+      "optional": true,
       "requires": {
         "is-docker": "^2.0.0"
       }
@@ -11350,6 +11351,7 @@
       "resolved": "https://registry.npmjs.org/node-notifier/-/node-notifier-8.0.1.tgz",
       "integrity": "sha512-BvEXF+UmsnAfYfoapKM9nGxnP+Wn7P91YfXmrKnfcYCx6VBeoN5Ez5Ogck6I8Bi5k4RlpqRYaw75pAwzX9OphA==",
       "dev": true,
+      "optional": true,
       "requires": {
         "growly": "^1.3.0",
         "is-wsl": "^2.2.0",
@@ -11364,6 +11366,7 @@
           "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.4.tgz",
           "integrity": "sha512-tCfb2WLjqFAtXn4KEdxIhalnRtoKFN7nAwj0B3ZXCbQloV2tq5eDbcTmT68JJD3nRJq24/XgxtQKFIpQdtvmVw==",
           "dev": true,
+          "optional": true,
           "requires": {
             "lru-cache": "^6.0.0"
           }
@@ -11372,13 +11375,15 @@
           "version": "8.3.2",
           "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
           "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-          "dev": true
+          "dev": true,
+          "optional": true
         },
         "which": {
           "version": "2.0.2",
           "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
           "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
           "dev": true,
+          "optional": true,
           "requires": {
             "isexe": "^2.0.0"
           }
@@ -12864,7 +12869,8 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/shellwords/-/shellwords-0.1.1.tgz",
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
-      "dev": true
+      "dev": true,
+      "optional": true
     },
     "side-channel": {
       "version": "1.0.4",

--- a/src/__mocks__/axios.js
+++ b/src/__mocks__/axios.js
@@ -1,8 +1,3 @@
-const cancelTokenSource = {
-  token: 'fake-cancel-token',
-  cancel: jest.fn(),
-};
-
 export default {
   request: jest.fn(
     (arg) =>
@@ -17,7 +12,4 @@ export default {
         });
       })
   ),
-  CancelToken: {
-    source: jest.fn(() => cancelTokenSource),
-  },
 };

--- a/src/__tests__/index.test.js
+++ b/src/__tests__/index.test.js
@@ -192,47 +192,6 @@ describe('redux-meta-object-to-axios-request', () => {
     });
   });
 
-  it('should cancel the request', async () => {
-    const action = {
-      meta: {
-        promise: {
-          url: 'fake-url',
-        },
-      },
-    };
-    let nextAction;
-    const next = jest.fn((a) => {
-      nextAction = a;
-      return 'whatever';
-    });
-    const axiosOptions = {
-      timeout: 100,
-    };
-    const cancelTokenSource = mockAxios.CancelToken.source();
-    reduxMetaObjectToAxiosPromise({
-      axiosOptions,
-      tokenOptions: createTokenOptions(),
-    })()(next)(action);
-    await nextAction.meta.promise;
-    expect(mockAxios.request).toHaveBeenCalledTimes(1);
-    expect(mockAxios.request).toHaveBeenCalledWith({
-      ...axiosOptions,
-      url: action.meta.promise.url,
-      method: 'get', // default value
-      headers: {},
-      transformResponse: expect.arrayContaining([expect.any(Function)]),
-      cancelToken: cancelTokenSource.token,
-    });
-    await new Promise((resolve) =>
-      setTimeout(() => {
-        expect(cancelTokenSource.cancel).toHaveBeenCalledWith(
-          `Timeout of ${axiosOptions.timeout}ms exceeded.`
-        );
-        resolve();
-      }, axiosOptions.timeout)
-    );
-  });
-
   it('should debounce the request based on given milliseconds (trailing by default)', async () => {
     const action = {
       meta: {
@@ -386,7 +345,6 @@ describe('redux-meta-object-to-axios-request', () => {
         expect.any(Function),
         ...axiosOptions.transformResponse,
       ]),
-      cancelToken: mockAxios.CancelToken.source().token,
     });
   });
 });


### PR DESCRIPTION
The api for cancellation is based on an [withdrawn cancellation promise proposal](https://github.com/axios/axios#cancellation) and in this particular case the timeout would produce the following error in the app when the library was properly used:

<img src="https://user-images.githubusercontent.com/5122417/108493337-dea28180-72ae-11eb-83bc-d373f7ee10cf.png" width="400" height="1000" />

When improperly set to `__DEV__ ? 60000 : 30000` timeout was `0`, given raise to some bugs like infinite loading workouts where axios would keep waiting for something that would never return.

By removing it altogether, the app itself now correctly `rejects` any longer than expected requests and triggers the `reject` action.

Obviously this is a major update if included.